### PR TITLE
Feat/walthrough changes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { Header } from "@/components/layout/header";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "FinReal - Real Estate Financial Modeling",
-  description: "Create and manage real estate development proformas with ease",
+  title: "FinReal",
+  description: "Real Estate Development Financial Analysis",
 };
 
 export default function RootLayout({
@@ -17,6 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
+        <Header />
         <div className="min-h-screen bg-background">
           {children}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,67 +26,50 @@ export default function HomePage() {
   }, [])
 
   return (
-    <div>
-      <header className="border-b">
-        <div className="container mx-auto px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center space-x-6">
-            <h1 className="text-xl font-semibold">FinReal</h1>
-            <nav>
-              <Link href="/" className="text-sm font-medium">Dashboard</Link>
-            </nav>
-          </div>
-          <div className="flex items-center gap-2">
-            <img src="/placeholder-logo.png" alt="Logo" className="h-8 w-8 rounded-full" />
-            <span className="text-sm font-medium">John Doe</span>
+    <main className="container mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-8">
+        <h2 className="text-2xl font-semibold">Projects</h2>
+        <Button asChild>
+          <Link href="/projects/new">Create New Project</Link>
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="bg-white rounded-lg border p-12 text-center">
+          <div className="animate-pulse space-y-4">
+            <div className="h-4 bg-gray-200 rounded w-1/4 mx-auto"></div>
+            <div className="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
+            <div className="h-10 bg-gray-200 rounded w-1/3 mx-auto"></div>
           </div>
         </div>
-      </header>
-      
-      <main className="container mx-auto px-4 py-8">
-        <div className="flex justify-between items-center mb-8">
-          <h2 className="text-2xl font-semibold">Projects</h2>
+      ) : projects.length === 0 ? (
+        <div className="bg-white rounded-lg border p-12 text-center">
+          <p className="text-lg text-gray-600 mb-4">No projects yet</p>
+          <p className="text-sm text-gray-500 mb-6">Create your first project to get started.</p>
           <Button asChild>
             <Link href="/projects/new">Create New Project</Link>
           </Button>
         </div>
-
-        {loading ? (
-          <div className="bg-white rounded-lg border p-12 text-center">
-            <div className="animate-pulse space-y-4">
-              <div className="h-4 bg-gray-200 rounded w-1/4 mx-auto"></div>
-              <div className="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
-              <div className="h-10 bg-gray-200 rounded w-1/3 mx-auto"></div>
-            </div>
-          </div>
-        ) : projects.length === 0 ? (
-          <div className="bg-white rounded-lg border p-12 text-center">
-            <p className="text-lg text-gray-600 mb-4">No projects yet</p>
-            <p className="text-sm text-gray-500 mb-6">Create your first project to get started.</p>
-            <Button asChild>
-              <Link href="/projects/new">Create New Project</Link>
-            </Button>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {projects.map((project) => (
-              <Link
-                key={project.id}
-                href={`/projects/${project.id}`}
-                className="block"
-              >
-                <div className="bg-white rounded-lg border p-6 hover:bg-accent transition-colors">
-                  <h3 className="text-lg font-semibold mb-2">{project.name}</h3>
-                  <p className="text-sm text-muted-foreground mb-4">{project.location}</p>
-                  <div className="flex justify-between text-sm">
-                    <span>Land Cost</span>
-                    <span className="font-medium">${project.landCost.toLocaleString()}</span>
-                  </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projects.map((project) => (
+            <Link
+              key={project.id}
+              href={`/projects/${project.id}`}
+              className="block"
+            >
+              <div className="bg-white rounded-lg border p-6 hover:bg-accent transition-colors">
+                <h3 className="text-lg font-semibold mb-2">{project.name}</h3>
+                <p className="text-sm text-muted-foreground mb-4">{project.location}</p>
+                <div className="flex justify-between text-sm">
+                  <span>Land Cost</span>
+                  <span className="font-medium">${project.landCost.toLocaleString()}</span>
                 </div>
-              </Link>
-            ))}
-          </div>
-        )}
-      </main>
-    </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,23 @@
+'use client'
+
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
+import { useEffect, useState } from "react"
+import { getProjects } from "@/lib/session-storage"
+import { Project } from "@/lib/mock-data"
 
 export default function HomePage() {
+  const [projects, setProjects] = useState<Project[]>([])
+
+  useEffect(() => {
+    const loadProjects = () => {
+      const projects = getProjects()
+      setProjects(projects)
+    }
+
+    loadProjects()
+  }, [])
+
   return (
     <div>
       <header className="border-b">
@@ -27,13 +43,34 @@ export default function HomePage() {
           </Button>
         </div>
 
-        <div className="bg-white rounded-lg border p-12 text-center">
-          <p className="text-lg text-gray-600 mb-4">No projects yet</p>
-          <p className="text-sm text-gray-500 mb-6">Create your first project to get started.</p>
-          <Button asChild>
-            <Link href="/projects/new">Create New Project</Link>
-          </Button>
-        </div>
+        {projects.length === 0 ? (
+          <div className="bg-white rounded-lg border p-12 text-center">
+            <p className="text-lg text-gray-600 mb-4">No projects yet</p>
+            <p className="text-sm text-gray-500 mb-6">Create your first project to get started.</p>
+            <Button asChild>
+              <Link href="/projects/new">Create New Project</Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {projects.map((project) => (
+              <Link
+                key={project.id}
+                href={`/projects/${project.id}`}
+                className="block"
+              >
+                <div className="bg-white rounded-lg border p-6 hover:bg-accent transition-colors">
+                  <h3 className="text-lg font-semibold mb-2">{project.name}</h3>
+                  <p className="text-sm text-muted-foreground mb-4">{project.location}</p>
+                  <div className="flex justify-between text-sm">
+                    <span>Land Cost</span>
+                    <span className="font-medium">${project.landCost.toLocaleString()}</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
       </main>
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,9 @@ export default function HomePage() {
               <Link href="/" className="text-sm font-medium">Dashboard</Link>
             </nav>
           </div>
-          <div className="flex items-center">
-            <span className="text-sm">a</span>
+          <div className="flex items-center gap-2">
+            <img src="/placeholder-logo.png" alt="Logo" className="h-8 w-8 rounded-full" />
+            <span className="text-sm font-medium">John Doe</span>
           </div>
         </div>
       </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,11 +8,18 @@ import { Project } from "@/lib/mock-data"
 
 export default function HomePage() {
   const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const loadProjects = () => {
-      const projects = getProjects()
-      setProjects(projects)
+      try {
+        const projects = getProjects()
+        setProjects(projects)
+      } catch (error) {
+        console.error("Error loading projects:", error)
+      } finally {
+        setLoading(false)
+      }
     }
 
     loadProjects()
@@ -43,7 +50,15 @@ export default function HomePage() {
           </Button>
         </div>
 
-        {projects.length === 0 ? (
+        {loading ? (
+          <div className="bg-white rounded-lg border p-12 text-center">
+            <div className="animate-pulse space-y-4">
+              <div className="h-4 bg-gray-200 rounded w-1/4 mx-auto"></div>
+              <div className="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
+              <div className="h-10 bg-gray-200 rounded w-1/3 mx-auto"></div>
+            </div>
+          </div>
+        ) : projects.length === 0 ? (
           <div className="bg-white rounded-lg border p-12 text-center">
             <p className="text-lg text-gray-600 mb-4">No projects yet</p>
             <p className="text-sm text-gray-500 mb-6">Create your first project to get started.</p>

--- a/src/app/projects/[id]/edit/page.tsx
+++ b/src/app/projects/[id]/edit/page.tsx
@@ -1,0 +1,252 @@
+'use client'
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import Link from "next/link"
+import { useForm, Controller } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { useRouter } from "next/navigation"
+import { use } from "react"
+import { getProject, saveProject } from "@/lib/session-storage"
+import { useEffect, useState } from "react"
+
+const projectSchema = z.object({
+  name: z.string().min(1, "Project name is required"),
+  notes: z.string().optional(),
+  city: z.string().min(1, "City is required"),
+  province: z.string().min(1, "Province is required"),
+  address: z.string().min(1, "Address is required"),
+  proformaType: z.string().min(1, "Proforma type is required"),
+  landCost: z.number().min(0, "Land cost must be greater than or equal to 0"),
+})
+
+type ProjectFormData = z.infer<typeof projectSchema>
+
+export default function EditProjectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [project, setProject] = useState<any>(null)
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ProjectFormData>({
+    resolver: zodResolver(projectSchema),
+  })
+
+  useEffect(() => {
+    const loadProject = () => {
+      try {
+        const projectData = getProject(id)
+        if (projectData) {
+          setProject(projectData)
+          // Split location into city and province
+          const [city, province] = projectData.location.split(',').map(s => s.trim())
+          reset({
+            name: projectData.name,
+            notes: projectData.notes || '',
+            city,
+            province: province.toLowerCase(),
+            address: projectData.address,
+            proformaType: projectData.proformaType,
+            landCost: projectData.landCost,
+          })
+        }
+      } catch (error) {
+        console.error("Error loading project:", error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadProject()
+  }, [id, reset])
+
+  const onSubmit = async (data: ProjectFormData) => {
+    try {
+      const updatedProject = {
+        ...project,
+        ...data,
+        location: `${data.city}, ${data.province}`,
+      }
+      saveProject(updatedProject)
+      router.push(`/projects/${id}`)
+    } catch (error) {
+      console.error("Failed to update project:", error)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card className="max-w-2xl mx-auto">
+          <CardContent className="p-6">
+            <div className="animate-pulse space-y-4">
+              <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+              <div className="space-y-2">
+                <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+                <div className="h-10 bg-gray-200 rounded"></div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!project) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card className="max-w-2xl mx-auto">
+          <CardContent className="p-6">
+            <p className="text-center text-gray-600">Project not found</p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="container mx-auto px-4 py-8">
+        <Card className="max-w-2xl mx-auto">
+          <CardHeader>
+            <CardTitle>Edit Project</CardTitle>
+            <p className="text-sm text-muted-foreground">Update the details for your project.</p>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Project Name</label>
+                <Input 
+                  placeholder="e.g. The Douglas Tower" 
+                  {...register("name")}
+                />
+                {errors.name && (
+                  <p className="text-sm text-destructive">{errors.name.message}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Project Notes</label>
+                <Textarea 
+                  placeholder="Additional details about this project" 
+                  {...register("notes")}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">City</label>
+                  <Input 
+                    placeholder="e.g. Toronto" 
+                    {...register("city")}
+                  />
+                  {errors.city && (
+                    <p className="text-sm text-destructive">{errors.city.message}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Province</label>
+                  <Controller
+                    name="province"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a province" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="on">Ontario</SelectItem>
+                          <SelectItem value="bc">British Columbia</SelectItem>
+                          <SelectItem value="ab">Alberta</SelectItem>
+                          <SelectItem value="qc">Quebec</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
+                  {errors.province && (
+                    <p className="text-sm text-destructive">{errors.province.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Address</label>
+                <Input 
+                  placeholder="e.g. 123 Main Street" 
+                  {...register("address")}
+                />
+                {errors.address && (
+                  <p className="text-sm text-destructive">{errors.address.message}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Proforma Type</label>
+                <Controller
+                  name="proformaType"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Pick a selection" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="condo">Condo</SelectItem>
+                        <SelectItem value="purpose-built-rental">Purpose Built Rental</SelectItem>
+                        <SelectItem value="land-development">Land Development</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+                {errors.proformaType && (
+                  <p className="text-sm text-destructive">{errors.proformaType.message}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Land Cost ($)</label>
+                <Input 
+                  type="number" 
+                  min={0} 
+                  {...register("landCost", { valueAsNumber: true })}
+                />
+                {errors.landCost && (
+                  <p className="text-sm text-destructive">{errors.landCost.message}</p>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-4">
+                <Button variant="outline" asChild>
+                  <Link href={`/projects/${id}`}>Cancel</Link>
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? "Saving..." : "Save Changes"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+} 

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -3,9 +3,10 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
-import { getProject } from "@/lib/mock-data"
 import { useEffect, useState, use } from "react"
 import { Project } from "@/lib/mock-data"
+import { getProject, getProformas } from "@/lib/session-storage"
+import { Proforma } from "@/lib/session-storage"
 
 const formatLocation = (location: string) => {
   const parts = location.split(',')
@@ -16,9 +17,10 @@ const formatLocation = (location: string) => {
 }
 
 const formatProformaType = (type: string) => {
-  return type.split(' ').map(word => 
-    word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-  ).join(' ')
+  return type
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
 }
 
 export default function ProjectDetailsPage({
@@ -28,21 +30,24 @@ export default function ProjectDetailsPage({
 }) {
   const { id } = use(params)
   const [project, setProject] = useState<Project | null>(null)
+  const [proformas, setProformas] = useState<Proforma[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    const fetchProject = async () => {
+    const fetchData = () => {
       try {
-        const data = await getProject(id)
-        setProject(data || null)
+        const projectData = getProject(id)
+        const proformasData = getProformas(id)
+        setProject(projectData || null)
+        setProformas(proformasData)
       } catch (error) {
-        console.error("Error fetching project:", error)
+        console.error("Error fetching data:", error)
       } finally {
         setLoading(false)
       }
     }
 
-    fetchProject()
+    fetchData()
   }, [id])
 
   if (loading) {
@@ -109,7 +114,7 @@ export default function ProjectDetailsPage({
             </CardHeader>
             <CardContent>
               <div className="space-y-4">
-                {project.proformas.map((proforma) => (
+                {proformas.map((proforma) => (
                   <Link
                     key={proforma.id}
                     href={`/projects/${id}/proformas/${proforma.id}`}
@@ -135,7 +140,7 @@ export default function ProjectDetailsPage({
                     </Card>
                   </Link>
                 ))}
-                {project.proformas.length === 0 && (
+                {proformas.length === 0 && (
                   <p className="text-sm text-muted-foreground text-center py-4">
                     No proformas yet. Create one to get started.
                   </p>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -7,6 +7,20 @@ import { getProject } from "@/lib/mock-data"
 import { useEffect, useState, use } from "react"
 import { Project } from "@/lib/mock-data"
 
+const formatLocation = (location: string) => {
+  const parts = location.split(',')
+  if (parts.length === 2) {
+    return parts[0].trim() + ', ' + parts[1].trim().toUpperCase()
+  }
+  return location
+}
+
+const formatProformaType = (type: string) => {
+  return type.split(' ').map(word => 
+    word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+  ).join(' ')
+}
+
 export default function ProjectDetailsPage({
   params
 }: {
@@ -63,7 +77,7 @@ export default function ProjectDetailsPage({
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <p className="text-sm text-muted-foreground">Location</p>
-                  <p className="font-medium">{project.location}</p>
+                  <p className="font-medium">{formatLocation(project.location)}</p>
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Address</p>
@@ -71,7 +85,7 @@ export default function ProjectDetailsPage({
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Proforma Type</p>
-                  <p className="font-medium">{project.proformaType}</p>
+                  <p className="font-medium">{formatProformaType(project.proformaType)}</p>
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Land Cost</p>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -5,8 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
 import { useEffect, useState, use } from "react"
 import { Project } from "@/lib/mock-data"
-import { getProject, getProformas } from "@/lib/session-storage"
-import { Proforma } from "@/lib/session-storage"
+import { getProject, getProformas, saveProforma, Proforma } from "@/lib/session-storage"
+import { useRouter } from "next/navigation"
 
 const formatLocation = (location: string) => {
   const parts = location.split(',')
@@ -29,6 +29,7 @@ export default function ProjectDetailsPage({
   params: Promise<{ id: string }>
 }) {
   const { id } = use(params)
+  const router = useRouter()
   const [project, setProject] = useState<Project | null>(null)
   const [proformas, setProformas] = useState<Proforma[]>([])
   const [loading, setLoading] = useState(true)
@@ -50,6 +51,54 @@ export default function ProjectDetailsPage({
     fetchData()
   }, [id])
 
+  const handleCreateProforma = () => {
+    const newProforma: Proforma = {
+      id: Date.now().toString(),
+      name: "New Proforma",
+      projectId: id,
+      lastUpdated: new Date().toISOString().split('T')[0],
+      totalCost: 0,
+      netProfit: 0,
+      roi: 0,
+      gba: 0,
+      stories: 0,
+      projectLength: 0,
+      absorptionPeriod: 0,
+      unitMix: [],
+      otherIncome: [],
+      sources: {
+        constructionDebt: 70,
+        equity: 30,
+        interestRate: 5.5,
+      },
+      uses: {
+        legalCosts: 0,
+        quantitySurveyorCosts: 0,
+        realtorFee: 2.5,
+        hardCostContingency: 10,
+        softCostContingency: 5,
+        additionalCosts: [],
+      },
+      results: {
+        totalProjectCost: 0,
+        netProfit: 0,
+        roi: 0,
+        costPerUnit: 0,
+      },
+      metrics: {
+        grossRevenue: 0,
+        totalExpenses: 0,
+        grossProfit: 0,
+        roi: 0,
+        annualizedRoi: 0,
+        leveredEmx: 0,
+      }
+    }
+
+    saveProforma(id, newProforma)
+    router.push(`/projects/${id}/proformas/${newProforma.id}`)
+  }
+
   if (loading) {
     return <div className="container mx-auto py-8">Loading...</div>
   }
@@ -66,9 +115,7 @@ export default function ProjectDetailsPage({
           <Link href={`/projects/${id}/edit`}>
             <Button variant="outline">Edit Project</Button>
           </Link>
-          <Link href={`/projects/${id}/proformas/new`}>
-            <Button>New Proforma</Button>
-          </Link>
+          <Button onClick={handleCreateProforma}>New Proforma</Button>
         </div>
       </div>
 

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -169,18 +169,32 @@ export default function ProjectDetailsPage({
                   >
                     <Card className="hover:bg-accent transition-colors">
                       <CardContent className="pt-6">
-                        <div className="flex justify-between items-start">
-                          <div>
-                            <p className="font-medium">{proforma.name}</p>
-                            <p className="text-sm text-muted-foreground">
-                              Last updated: {proforma.lastUpdated}
-                            </p>
+                        <div className="flex flex-col gap-2">
+                          <div className="flex justify-between items-start">
+                            <div>
+                              <p className="font-medium text-lg">{proforma.name}</p>
+                              <p className="text-sm text-muted-foreground">
+                                Last updated: {proforma.lastUpdated}
+                              </p>
+                            </div>
+                            <div className="text-right">
+                              <p className="font-medium text-xl">${proforma.results?.totalProjectCost?.toLocaleString() ?? proforma.totalCost?.toLocaleString() ?? '—'}</p>
+                              <p className="text-xs text-muted-foreground">Total Cost</p>
+                            </div>
                           </div>
-                          <div className="text-right">
-                            <p className="font-medium">${proforma.totalCost.toLocaleString()}</p>
-                            <p className="text-sm text-muted-foreground">
-                              ROI: {proforma.roi}%
-                            </p>
+                          <div className="grid grid-cols-2 gap-2 mt-2">
+                            <div>
+                              <span className="block text-xs text-muted-foreground">Net Profit</span>
+                              <span className="font-semibold">${proforma.results?.netProfit?.toLocaleString() ?? proforma.netProfit?.toLocaleString() ?? '—'}</span>
+                            </div>
+                            <div>
+                              <span className="block text-xs text-muted-foreground">ROI</span>
+                              <span className="font-semibold">{proforma.results?.roi?.toFixed(1) ?? proforma.roi?.toFixed(1) ?? '—'}%</span>
+                            </div>
+                            <div>
+                              <span className="block text-xs text-muted-foreground">Cost per Unit</span>
+                              <span className="font-semibold">${proforma.results?.costPerUnit?.toLocaleString() ?? '—'}</span>
+                            </div>
                           </div>
                         </div>
                       </CardContent>

--- a/src/app/projects/[id]/proformas/[proformaId]/page.tsx
+++ b/src/app/projects/[id]/proformas/[proformaId]/page.tsx
@@ -83,6 +83,8 @@ export default function ProformaEditorPage({
   const [absorptionPeriodValue, setAbsorptionPeriodValue] = useState<string>('')
   const [editingUnitGroup, setEditingUnitGroup] = useState<{ unitTypeId: string, groupKey: string } | null>(null)
   const [unitDialogMode, setUnitDialogMode] = useState<'add' | 'edit'>('add')
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [proformaName, setProformaName] = useState('')
 
   const unitTypeDisplayNames: Record<string, string> = {
     parking: 'Parking Space',
@@ -96,6 +98,8 @@ export default function ProformaEditorPage({
         const data = getProforma(id, proformaId)
         if (data) {
           setProforma(data)
+          setProformaName(data.name)
+          setIsEditingName(data.name === "New Proforma")
           setGbaValue(data.gba?.toString() ?? '')
           setStoriesValue(data.stories?.toString() ?? '')
           setProjectLengthValue(data.projectLength?.toString() ?? '')
@@ -453,6 +457,20 @@ export default function ProformaEditorPage({
     return Array.from(map.values());
   }
 
+  const handleNameChange = (newName: string) => {
+    if (!proforma) return
+    setProformaName(newName)
+    const updatedProforma: Proforma = {
+      ...proforma,
+      name: newName
+    }
+    setProforma(prev => {
+      if (!prev) return prev;
+      return updatedProforma;
+    })
+    saveProforma(id, updatedProforma)
+  }
+
   if (loading) {
     return <div className="container mx-auto py-8">Loading...</div>
   }
@@ -464,7 +482,25 @@ export default function ProformaEditorPage({
   return (
     <div className="container mx-auto py-8">
       <div className="flex justify-between items-center mb-8">
-        <h1 className="text-3xl font-bold">{proforma.name}</h1>
+        <div className="flex-1 max-w-2xl">
+          {isEditingName ? (
+            <Input
+              value={proformaName}
+              onChange={(e) => handleNameChange(e.target.value)}
+              onBlur={() => setIsEditingName(false)}
+              className="text-3xl font-bold h-12 px-2"
+              autoFocus={proformaName === "New Proforma"}
+              placeholder="Enter proforma name"
+            />
+          ) : (
+            <h1 
+              className="text-3xl font-bold cursor-pointer hover:bg-muted/50 px-2 py-1 rounded"
+              onClick={() => setIsEditingName(true)}
+            >
+              {proformaName || "Untitled Proforma"}
+            </h1>
+          )}
+        </div>
         <div className="flex gap-4">
           <Button variant="outline">Export to PDF</Button>
           <Link href={`/projects/${id}`}>

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -30,7 +30,7 @@ const testData: ProjectFormData = {
   city: "Toronto",
   province: "on",
   address: "123 Douglas Street",
-  proformaType: "residential",
+  proformaType: "condo",
   landCost: 15000000,
 }
 
@@ -74,7 +74,7 @@ export default function NewProjectPage() {
         <Card className="max-w-2xl mx-auto">
           <CardHeader>
             <CardTitle>Create New Project</CardTitle>
-            <p className="text-sm text-muted-foreground">Enter the details for your new development project.</p>
+            <p className="text-sm text-muted-foreground">Enter the details for your project.</p>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
@@ -158,12 +158,12 @@ export default function NewProjectPage() {
                       onValueChange={field.onChange}
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder="Select a type" />
+                        <SelectValue placeholder="Pick a selection" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="residential">Residential</SelectItem>
-                        <SelectItem value="commercial">Commercial</SelectItem>
-                        <SelectItem value="mixed">Mixed Use</SelectItem>
+                        <SelectItem value="condo">Condo</SelectItem>
+                        <SelectItem value="purpose-built-rental">Purpose Built Rental</SelectItem>
+                        <SelectItem value="land-development">Land Development</SelectItem>
                       </SelectContent>
                     </Select>
                   )}

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -10,7 +10,7 @@ import { useForm, Controller } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
 import { useRouter } from "next/navigation"
-import { createProject } from "@/lib/mock-data"
+import { saveProject } from "@/lib/session-storage"
 
 const projectSchema = z.object({
   name: z.string().min(1, "Project name is required"),
@@ -53,10 +53,13 @@ export default function NewProjectPage() {
 
   const onSubmit = async (data: ProjectFormData) => {
     try {
-      const project = await createProject({
+      const project = {
+        id: Date.now().toString(),
         ...data,
         location: `${data.city}, ${data.province}`,
-      })
+        proformas: [],
+      }
+      saveProject(project)
       router.push(`/projects/${project.id}`)
     } catch (error) {
       console.error("Failed to create project:", error)

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import Link from "next/link"
+
+export function Header() {
+  return (
+    <header className="border-b bg-white">
+      <div className="container mx-auto px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center space-x-6">
+          <h1 className="text-xl font-semibold">FinReal</h1>
+          <nav>
+            <Link href="/" className="text-sm font-medium hover:text-primary transition-colors">Projects</Link>
+          </nav>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">John Doe</span>
+          <img src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_640.png" alt="Logo" className="h-8 w-8 rounded-full" />
+        </div>
+      </div>
+    </header>
+  )
+} 

--- a/src/lib/session-storage.ts
+++ b/src/lib/session-storage.ts
@@ -1,0 +1,136 @@
+import { Project } from "./mock-data"
+
+// Types
+export interface Proforma {
+    id: string
+    name: string
+    projectId: string
+    lastUpdated: string
+    totalCost: number
+    netProfit: number
+    roi: number
+    gba: number
+    stories: number
+    projectLength: number
+    absorptionPeriod: number
+    unitMix: UnitType[]
+    otherIncome: OtherIncome[]
+    sources: {
+        constructionDebt: number
+        equity: number
+        interestRate: number
+    }
+    uses: {
+        legalCosts: number
+        quantitySurveyorCosts: number
+        realtorFee: number
+        hardCostContingency: number
+        softCostContingency: number
+        additionalCosts: Array<{ name: string; amount: number }>
+    }
+    results: {
+        totalProjectCost: number
+        netProfit: number
+        roi: number
+        costPerUnit: number
+    }
+    metrics: {
+        grossRevenue: number
+        totalExpenses: number
+        grossProfit: number
+        roi: number
+        annualizedRoi: number
+        leveredEmx: number
+    }
+}
+
+export interface Unit {
+    id: string
+    name: string
+    area: number
+    value: number
+}
+
+export interface UnitType {
+    id: string
+    name: string
+    description: string
+    units: Unit[]
+}
+
+export interface OtherIncome {
+    id: string
+    name: string
+    description: string
+    value: number
+    unitType: string
+    numberOfUnits: number
+    valuePerUnit: number
+    customUnitType?: string
+}
+
+// Session Storage Keys
+const PROJECTS_KEY = 'finreal_projects'
+const PROFORMAS_KEY = 'finreal_proformas'
+
+// Project Operations
+export function getProjects(): Project[] {
+    if (typeof window === 'undefined') return []
+    const projects = sessionStorage.getItem(PROJECTS_KEY)
+    return projects ? JSON.parse(projects) : []
+}
+
+export function getProject(id: string): Project | null {
+    const projects = getProjects()
+    return projects.find(p => p.id === id) || null
+}
+
+export function saveProject(project: Project): void {
+    const projects = getProjects()
+    const index = projects.findIndex(p => p.id === project.id)
+
+    if (index >= 0) {
+        projects[index] = project
+    } else {
+        projects.push(project)
+    }
+
+    sessionStorage.setItem(PROJECTS_KEY, JSON.stringify(projects))
+}
+
+export function deleteProject(id: string): void {
+    const projects = getProjects()
+    const filteredProjects = projects.filter(p => p.id !== id)
+    sessionStorage.setItem(PROJECTS_KEY, JSON.stringify(filteredProjects))
+}
+
+// Proforma Operations
+export function getProformas(projectId: string): Proforma[] {
+    if (typeof window === 'undefined') return []
+    const proformas = sessionStorage.getItem(`${PROFORMAS_KEY}_${projectId}`)
+    return proformas ? JSON.parse(proformas) : []
+}
+
+export function getProforma(projectId: string, proformaId: string): Proforma | null {
+    const proformas = getProformas(projectId)
+    return proformas.find(p => p.id === proformaId) || null
+}
+
+export function saveProforma(projectId: string, proforma: Proforma): void {
+    const proformas = getProformas(projectId)
+    const index = proformas.findIndex(p => p.id === proforma.id)
+
+    if (index >= 0) {
+        proformas[index] = proforma
+    } else {
+        proformas.push(proforma)
+    }
+
+    sessionStorage.setItem(`${PROFORMAS_KEY}_${projectId}`, JSON.stringify(proformas))
+}
+
+export function deleteProforma(projectId: string, proformaId: string): void {
+    const proformas = getProformas(projectId)
+    const filteredProformas = proformas.filter(p => p.id !== proformaId)
+    sessionStorage.setItem(`${PROFORMAS_KEY}_${projectId}`, JSON.stringify(filteredProformas))
+} 


### PR DESCRIPTION

>Top corner - name of company and logo, instead of "a". Same logo and name wil be used on the pdf. - DONE
>'Edit project' button from project screen brings you to 404 page. back button as well - I think this is because projects are not actually saved anywhere. Make all back button and navigation work, flow from page to page, save things locally. -DONE


--------Create new project screen 
>'Proforma type' dropdown should be instead - condo, condo, purpose built rental and land development. Subtitle should be 'Enter the details for your project'. Other than that rest of fields are fine. -DONE

---- Project Screen
>Location, Capitalize the On in Toronto, ON, Properly capitalize the proforma type as well. - DONE


------Edit proforma screen


---General
>Change general information subtitle from "basic project details and timeline' to 'Salient project details' - DONE
>GBA - change to allow decimal entries - DONE

----Unit Mix
>Add unit popup - Value per unit - change to Price per square foot, 
Show calculation under area * price per square foot. -DONE
>Clicking on an existing unit that has been added, should open back up the "add unit" to allow for edits.  - DONE
>Collate the units if they are of the same type instead of showing 40 individual listed items, we show ont item and the quantity as 40. - DONE

----Other Income
> List items here - instead of 12 parkings(s) should be 12 parking spaces, take dropdown display value not actual value. - DONE